### PR TITLE
store site info to plot running jobs per site.

### DIFF
--- a/condor_queue_to_es.py
+++ b/condor_queue_to_es.py
@@ -28,9 +28,9 @@ options.indexname += '-'+now.strftime("%Y.%m.%d")
 # key filter
 keys = {
     'RequestCpus','Requestgpus', 'RequestMemory', 'RequestDisk',
-    'NumJobStarts', 'NumShadowStarts', 'ClusterId', 'ProcId',
+    'NumJobStarts', 'NumShadowStarts',
     'GlobalJobId', '@timestamp', 'queue_time', 'Owner',
-    'JobStatus',
+    'JobStatus','MATCH_EXP_JOBGLIDEIN_ResourceName',
 }
 
 def es_generator(entries):


### PR DESCRIPTION
I don't think we need the clusterid/procid in the queue DB... we can save those two