### PR TITLE
Track resource claims from jobs, both finished and evicted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 RUN yum -y install epel-release && \
     yum -y upgrade ca-certificates --disablerepo=epel && \
     yum install -y python-pip && \
-    pip install elasticsearch htcondor requests
+    pip install 'elasticsearch>=6.0.0,<7.0.0' 'elasticsearch-dsl>=6.0.0,<7.0.0' htcondor requests
 
 COPY . /monitoring
 

--- a/condor_status_to_es.py
+++ b/condor_status_to_es.py
@@ -1,20 +1,32 @@
 #!/usr/bin/env python
 """
-Read from condor history and write to elasticsearch
+Read from condor status and write to elasticsearch
 """
 
 from __future__ import print_function
-import os
-import glob
-from argparse import ArgumentParser
-import logging
-from functools import partial
 
+import glob
+import json
+import logging
+import os
 import re
+import textwrap
+from argparse import ArgumentParser
 from datetime import datetime, timedelta
+from functools import partial
 from time import mktime
 
-regex = re.compile(r'((?P<days>\d+?)d)?((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?')
+import elasticsearch_dsl as edsl
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import bulk
+from elasticsearch_dsl import MultiSearch, Search
+
+from condor_utils import *
+
+regex = re.compile(
+    r"((?P<days>\d+?)d)?((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?"
+)
+
 
 def parse_time(time_str):
     parts = regex.match(time_str)
@@ -27,50 +39,322 @@ def parse_time(time_str):
             time_params[name] = int(param)
     return timedelta(**time_params)
 
-parser = ArgumentParser('usage: %prog [options] collector_addresses')
-parser.add_argument('-a','--address',help='elasticsearch address')
-parser.add_argument('-n','--indexname',default='condor_status',
-                  help='index name (default condor_status)')
-parser.add_argument('--after', default=timedelta(hours=1),
-                  help='time to look back', type=parse_time)
-parser.add_argument('-y', '--dry-run', default=False, action='store_true',
-                  help='query status, but do not ingest into ES')
-parser.add_argument('collectors', nargs='+')
+
+parser = ArgumentParser("usage: %prog [options] collector_addresses")
+parser.add_argument("-a", "--address", help="elasticsearch address")
+parser.add_argument(
+    "-n",
+    "--indexname",
+    default="condor_status",
+    help="index name (default condor_status)",
+)
+parser.add_argument(
+    "--after", default=timedelta(hours=1), help="time to look back", type=parse_time
+)
+parser.add_argument(
+    "-y",
+    "--dry-run",
+    default=False,
+    action="store_true",
+    help="query status, but do not ingest into ES",
+)
+parser.add_argument("collectors", nargs="+")
 options = parser.parse_args()
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(name)s : %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s : %(message)s"
+)
 
 
-from condor_utils import *
+# note different capitalization conventions for GPU and Cpu
+RESOURCES = ("GPUs", "Cpus", "Memory", "Disk")
+STATUSES = ("evicted", "removed", "finished")
+
 
 def es_generator(entries):
+    """
+    Generate upsert ops from machine classad dictionaries
+    """
     for data in entries:
-        data['_index'] = options.indexname
-        data['_type'] = 'machine_ad'
-        data['_id'] = '{:.0f}-{:s}'.format(time.mktime(data['DaemonStartTime'].timetuple()),data['Name'])
-        if not data['_id']:
+        yield {
+            "_index": options.indexname,
+            "_op_type": "update",
+            "_type": "machine_ad",
+            "_id": "{:.0f}-{:s}".format(
+                time.mktime(data["DaemonStartTime"].timetuple()), data["Name"]
+            ),
+            "doc": data,
+            "doc_as_upsert": True,
+        }
+
+
+def update_claims(entries, history=False):
+    """
+    Generate updates to claims.* from job classad dictionaries
+    """
+    def parent_slot_name(dynamic_slot_name):
+        parts = dynamic_slot_name.split("@")
+        match = re.match(r"(slot\d+)_\d+", parts[0])
+        if match:
+            parts[0] = match.group(1)
+        return "@".join(parts)
+
+    # MultiSearch will fail if there are no queries to run
+    jobs = list(entries)
+    if not jobs:
+        return
+
+    # glidein names are not necessarily unique on long time scales. look up the
+    # last glidein that started with the advertised name _before_ the evicted
+    # job was started
+    ms = MultiSearch(using=es, index=options.indexname)
+    for hit in jobs:
+        if history:
+            t0 = hit["JobCurrentStartDate"]
+        else:
+            t0 = hit["JobLastStartDate"]
+        ms = ms.add(
+            Search()
+            .filter("term", Name__keyword=parent_slot_name(hit["LastRemoteHost"]))
+            .filter("range", DaemonStartTime={"lte": datetime.utcfromtimestamp(t0)},)
+            .sort({"DaemonStartTime": {"order": "desc"}})
+            .source(["nuthin"])[:1]
+        )
+
+    for hit, match in zip(jobs, ms.execute()):
+        if not match.hits:
             continue
-        yield data
+        if history:
+            if hit["JobStatus"] == 3:
+                category = "removed"
+            else:
+                category = "finished"
+            walltime = float(hit["EnteredCurrentStatus"] - hit["JobCurrentStartDate"])
+        else:
+            walltime = float(hit["LastVacateTime"] - hit["JobLastStartDate"])
+            category = "evicted"
 
-from elasticsearch import Elasticsearch
-from elasticsearch.helpers import bulk
-import json
+        # normalize capitalization of requests
+        requests = {resource: 0 for resource in RESOURCES}
+        for k in hit:
+            if k.startswith("Request"):
+                requests[k[7:]] = walltime * hit[k]
 
-prefix = 'http'
+        doc = {
+            "_op_type": "update",
+            "_index": match.hits[0].meta.index,
+            "_type": match.hits[0].meta.doc_type,
+            "_id": match.hits[0].meta.id,
+            "script": {
+                "id": options.indexname + "-update-claims",
+                "params": {
+                    "job": hit["GlobalJobId"].replace("#", "-").replace(".", "-"),
+                    "category": category,
+                    "requests": requests,
+                },
+            },
+        }
+        yield doc
+
+
+prefix = "http"
 address = options.address
-if '://' in address:
-    prefix,address = address.split('://')
+if "://" in address:
+    prefix, address = address.split("://")
 
-url = '{}://{}'.format(prefix, address)
-logging.info('connecting to ES at %s',url)
-es = Elasticsearch(hosts=[url],
-                   timeout=5000)
-es_import = partial(bulk, es, max_retries=20, initial_backoff=2, max_backoff=3600)
+url = "{}://{}".format(prefix, address)
+logging.info("connecting to ES at %s", url)
+es = Elasticsearch(hosts=[url], timeout=5000)
+
+
+def es_import(document_generator):
+    if options.dry_run:
+        for hit in document_generator:
+            logging.info(hit)
+        success = True
+    else:
+        success, _ = bulk(es, gen, max_retries=20, initial_backoff=2, max_backoff=3600)
+    return success
+
+
+machine_ad = edsl.Mapping.from_es(
+    doc_type="machine_ad", index=options.indexname, using=es
+)
+if not "claims" in machine_ad:
+    machine_ad.field(
+        "jobs",
+        edsl.Object(properties={status: edsl.Text(multi=True) for status in STATUSES}),
+    )
+    machine_ad.field(
+        "claims",
+        edsl.Object(
+            properties={
+                status: edsl.Object(
+                    properties={resource: edsl.Float() for resource in RESOURCES}
+                )
+                for status in STATUSES
+            }
+        ),
+    )
+    machine_ad.save(options.indexname, using=es)
+    machine_ad.field(
+        "occupancy",
+        edsl.Object(
+            properties={
+                status: edsl.Object(
+                    properties={resource: edsl.Float() for resource in RESOURCES}
+                )
+                for status in STATUSES + ("total",)
+            }
+        ),
+    )
+    machine_ad.field("duration", edsl.Integer())
+    machine_ad.save(options.indexname, using=es)
+    # Claim update, triggered each time a job is removed from a machine
+    es.put_script(
+        options.indexname + "-update-claims",
+        {
+            "script": {
+                "source": textwrap.dedent(
+                    """
+                    def resources = """
+                    + repr(list(RESOURCES))
+                    + """;
+                    if(ctx._source["jobs."+params.category] == null) {
+                        ctx._source["jobs."+params.category] = [];
+                        for (resource in resources) {
+                            ctx._source["claims."+params.category+"."+resource] = 0;
+                        }
+                    }
+                    if(!ctx._source["jobs."+params.category].contains(params.job)) {
+                        ctx._source["jobs."+params.category].add(params.job);
+                        for (resource in resources) {
+                            if (params.requests.containsKey(resource)) {
+                                ctx._source["claims."+params.category+"."+resource] += params.requests[resource];
+                            }
+                        }
+                        // reset duration so that occupancy will be recalculated in
+                        // the next run
+                        ctx._source.duration = null;
+                    } else {
+                        ctx.op = "none";
+                    }
+                    """
+                ),
+                "lang": "painless",
+                "context": "update",
+            }
+        },
+    )
+
+    # Occupancy update, once per run
+    es.put_script(
+        options.indexname + "-update-occupancy",
+        {
+            "script": {
+                "source": textwrap.dedent(
+                    """
+                    def RESOURCES = """
+                    + repr(list(RESOURCES))
+                    + """;
+                    def STATUSES = """
+                    + repr(list(STATUSES))
+                    + """;
+                    long current_duration = Duration.between(
+                        LocalDateTime.parse(ctx._source.DaemonStartTime),
+                        LocalDateTime.parse(ctx._source.LastHeardFrom)
+                        ).toMillis()/1000;
+                    if(ctx._source.duration == null
+                        || ctx._source.duration != current_duration) {
+                        ctx._source.duration = current_duration;
+                        for (resource in RESOURCES) {
+                            if (!ctx._source.containsKey("Total"+resource)) {
+                                continue;
+                            }
+                            double norm = (current_duration*ctx._source["Total"+resource]).doubleValue();
+                            if (!(norm > 0)) {
+                                continue;
+                            }
+                            double total = 0;
+                            for (status in STATUSES) {
+                                def key = status+"."+resource;
+                                // def blerh = ctx._source["claims."+key]/norm;
+                                if (ctx._source["claims."+key] != null) {
+                                    ctx._source["occupancy."+key] = ctx._source["claims."+key]/norm;
+                                    total += ctx._source["claims."+key]/norm;
+                                } else {
+                                    ctx._source["occupancy."+key] = 0;
+                                }
+                            }
+                            ctx._source["occupancy.total."+resource] = total;
+                        }
+                    } else {
+                        ctx.op = "noop";
+                    }
+                    """
+                ),
+                "lang": "painless",
+                "context": "update",
+            }
+        },
+    )
 
 for coll_address in options.collectors:
-    gen = es_generator(read_status_from_collector(coll_address, datetime.now()-options.after))
-    if options.dry_run:
-        for hit in gen:
-            logging.info(hit)
-    else:
-        success, _ = es_import(gen)
+
+    gen = es_generator(
+        read_status_from_collector(coll_address, datetime.now() - options.after)
+    )
+    success = es_import(gen)
+
+    # Update claims from evicted jobs
+    gen = update_claims(
+        read_from_collector(
+            coll_address,
+            constraint="(LastVacateTime > {}) && ((LastVacateTime-JobLastStartDate))>60".format(
+                time.mktime((datetime.now() - timedelta(minutes=10)).timetuple())
+            ),
+            projection=[
+                "GlobalJobId",
+                "NumJobStarts",
+                "JobLastStartDate",
+                "LastVacateTime",
+                "LastRemoteHost",
+            ]
+            + ["Request" + resource for resource in RESOURCES],
+        ),
+        history=False,
+    )
+    success = es_import(gen)
+
+    # Update claims from finished jobs
+    gen = update_claims(
+        read_from_collector(
+            coll_address,
+            constraint="!isUndefined(LastRemoteHost)",
+            projection=[
+                "GlobalJobId",
+                "NumJobStarts",
+                "JobLastStartDate",
+                "JobCurrentStartDate",
+                "EnteredCurrentStatus",
+                "JobStatus",
+                "LastRemoteHost",
+            ]
+            + ["Request" + resource for resource in RESOURCES],
+            history=True,
+        ),
+        history=True,
+    )
+    success = es_import(gen)
+
+# Normalize claims to running time to get occupancy of each slot. Note that
+# these updates can conflict with the ones issued just before by update_claims.
+# Skip these with conflicts=proceed, as they will get picked up in the next run
+# anyhow.
+if not options.dry_run:
+    (
+        edsl.UpdateByQuery(index=options.indexname, using=es)
+        .filter("range", LastHeardFrom={"gte": datetime.utcnow() - options.after},)
+        .script(id=options.indexname + "-update-occupancy",)
+        .params(conflicts="proceed")
+    ).execute()

--- a/condor_utils.py
+++ b/condor_utils.py
@@ -815,7 +815,10 @@ def read_status_from_collector(address, after=datetime.now()-timedelta(hours=1))
             data = classad_to_dict(entry)
             for k in "DaemonStartTime", "LastHeardFrom":
                 data[k] = datetime.utcfromtimestamp(data[k])
-            data["@timestamp"] = datetime.utcnow()
+            data["@timestamp"] = [data["DaemonStartTime"]]
+            if data["LastHeardFrom"] > data["DaemonStartTime"]:
+                data["@timestamp"].append(data["LastHeardFrom"])
+            data["duration"] = int((data["LastHeardFrom"]-data["DaemonStartTime"]).total_seconds())
             if not 'GLIDEIN_ResourceName' in data:
                 data['GLIDEIN_ResourceName'] = data['GLIDEIN_Site']
             # add site

--- a/condor_utils.py
+++ b/condor_utils.py
@@ -234,192 +234,100 @@ reserved_domains = {
     'zeuthen.desy.de': 'DESY-ZN',
 }
 
-site_names = {
-    'DESY-ZN': 'DE-DESY',
-    'DESY-HH': 'DE-DESY',
-    'DESY': 'DE-DESY',
-    'Brussels': 'BE-IIHE',
-    'T2B_BE_IIHE': 'BE-IIHE',
-    'BEgrid-ULB-VUB': 'BE-IIHE',
-    'Guillimin': 'CA-McGill',
-    'CA-MCGILL-CLUMEQ-T2': 'CA-McGill',
-    'mainz': 'DE-Mainz',
-    'mainzgrid': 'DE-Mainz',
-    'Mainz_MogonI': 'DE-Mainz',
-    'CA-SCINET-T2': 'CA-Toronto',
-    'Alberta': 'CA-Alberta',
-    'parallel': 'CA-Alberta',
-    'jasper': 'CA-Alberta',
-    'Illume': 'CA-Alberta',
-    'illume': 'CA-Alberta',
-    'illume-new': 'CA-Alberta',
-    'Cedar': 'CA-SFU',
-    'RWTH-Aachen': 'DE-Aachen',
-    'aachen': 'DE-Aachen',
-    'wuppertalprod': 'DE-Wuppertal',
-    'TUM': 'DE-Munich',
-    'Uppsala': 'SE-Uppsala',
-    'Bartol': 'US-Bartol',
-    'UNI-DORTMUND': 'DE-Dortmund',
-    'LIDO_Dortmund': 'DE-Dortmund',
-    'PHIDO_Dortmund': 'DE-Dortmund',
-    'LIDO3_Dortmund_TEST': 'DE-Dortmund',
-    'UKI-NORTHGRID-MAN-HEP': 'UK-Manchester',
-    'UKI-LT2-QMUL': 'UK-Manchester',
-    'Bridges': 'US-XSEDE-PSC',
-    'Comet': 'US-XSEDE-SDSC',
-    'HOSTED_STANFORD': 'XSEDE-XStream',
-    'Xstream': 'US-XSEDE-Stanford',
-    'xstream': 'US-XSEDE-Stanford',
-    'NPX': 'US-NPX',
-    'GZK': 'US-GZK',
-    'CHTC': 'US-CHTC',
-    'Marquette': 'US-Marquette',
-    'UMD': 'US-UMD',
-    'MSU': 'US-MSU',
-    'msu': 'US-MSU',
-    'PSU': 'US-PSU',
-    'Japan': 'JP-Chiba',
-    'Chiba': 'JP-Chiba',
-    'nbi': 'DK-NBI',
-    'NBI': 'DK-NBI',
-    'NBI_T3': 'DK-NBI',
-    'SDSC-PRP': 'US-OSG-UCSD',
-    'SU-ITS-CE3': 'US-OSG-Syracuse',
-    'SU-ITS-CE2': 'US-OSG-Syracuse',
-    'Syracuse': 'US-OSG-Syracuse',
-    'Crane': 'US-OSG-Crane',
-    'UCSDT2': 'US-OSG-UCSDT2',
-    'BNL-ATLAS': 'US-OSG-BNL-ATLAS',
-    'CIT_CMS_T2': 'US-OSG-Caltech-HEP',
-    'Indiana': 'US-OSG-MWT2',
-    'Stampede2': 'US-XSEDE-TACC',
-    'Clemson-Palmetto': 'US-OSG-Clemson'
-}
+def get_site_from_resource(resource):
+    site_names = {
+        'DESY-ZN': 'DE-DESY',
+        'DESY-HH': 'DE-DESY',
+        'DESY': 'DE-DESY',
+        'Brussels': 'BE-IIHE',
+        'T2B_BE_IIHE': 'BE-IIHE',
+        'BEgrid-ULB-VUB': 'BE-IIHE',
+        'Guillimin': 'CA-McGill',
+        'CA-MCGILL-CLUMEQ-T2': 'CA-McGill',
+        'mainz': 'DE-Mainz',
+        'mainzgrid': 'DE-Mainz',
+        'Mainz_MogonI': 'DE-Mainz',
+        'CA-SCINET-T2': 'CA-Toronto',
+        'Alberta': 'CA-Alberta',
+        'parallel': 'CA-Alberta',
+        'jasper': 'CA-Alberta',
+        'Illume': 'CA-Alberta',
+        'illume': 'CA-Alberta',
+        'illume-new': 'CA-Alberta',
+        'Cedar': 'CA-SFU',
+        'RWTH-Aachen': 'DE-Aachen',
+        'aachen': 'DE-Aachen',
+        'wuppertalprod': 'DE-Wuppertal',
+        'TUM': 'DE-Munich',
+        'Uppsala': 'SE-Uppsala',
+        'Bartol': 'US-Bartol',
+        'UNI-DORTMUND': 'DE-Dortmund',
+        'LIDO_Dortmund': 'DE-Dortmund',
+        'PHIDO_Dortmund': 'DE-Dortmund',
+        'LIDO3_Dortmund_TEST': 'DE-Dortmund',
+        'LiDO3_Dortmund': 'DE-Dortmund',
+        'UKI-NORTHGRID-MAN-HEP': 'UK-Manchester',
+        'UKI-LT2-QMUL': 'UK-Manchester',
+        'Bridges': 'US-XSEDE-PSC',
+        'Comet': 'US-XSEDE-SDSC',
+        'HOSTED_STANFORD': 'XSEDE-XStream',
+        'Xstream': 'US-XSEDE-Stanford',
+        'xstream': 'US-XSEDE-Stanford',
+        'NPX': 'US-NPX',
+        'GZK': 'US-GZK',
+        'CHTC': 'US-CHTC',
+        'Marquette': 'US-Marquette',
+        'UMD': 'US-UMD',
+        'MSU': 'US-MSU',
+        'msu': 'US-MSU',
+        'PSU': 'US-PSU',
+        'Japan': 'JP-Chiba',
+        'Chiba': 'JP-Chiba',
+        'nbi': 'DK-NBI',
+        'NBI': 'DK-NBI',
+        'NBI_T3': 'DK-NBI',
+        'SDSC-PRP': 'US-OSG-UCSD',
+        'SU-ITS-CE3': 'US-OSG-Syracuse',
+        'SU-ITS-CE2': 'US-OSG-Syracuse',
+        'Syracuse': 'US-OSG-Syracuse',
+        'Crane': 'US-OSG-Crane',
+        'UCSDT2': 'US-OSG-UCSDT2',
+        'BNL-ATLAS': 'US-OSG-BNL-ATLAS',
+        'CIT_CMS_T2': 'US-OSG-Caltech-HEP',
+        'Indiana': 'US-OSG-MWT2',
+        'MWT2':  'US-OSG-MWT2',
+        'Stampede2': 'US-XSEDE-TACC',
+        'Clemson-Palmetto': 'US-OSG-Clemson',
+        'SLATE_US_UIUC_HTC': 'US-OSG-UIUC',
+        'SLATE_US_UUTAH_KINGSPEAK': 'US-OSG-UUTAH',
+        'SLATE_US_UUTAH_LONEPEAK': 'US-OSG-UUTAH',
+        'SLATE_US_UUTAH_NOTCHPEAK': 'US-OSG-UUTAH',
+    }
+    if resource in site_names:
+        return site_names[resource]
+    elif resource.startswith('SLATE'):
+        parts = resource.split('_')[1:]
+        return '-'.join([parts[0], 'OSG', parts[1]])
+    else:
+        return 'other'
 
-countries = {
-    'DESY-ZN': 'DE',
-    'DESY-HH': 'DE',
-    'DESY': 'DE',
-    'Brussels': 'BE',
-    'T2B_BE_IIHE': 'BE',
-    'BEgrid-ULB-VUB': 'BE',
-    'Guillimin': 'CA',
-    'CA-MCGILL-CLUMEQ-T2': 'CA',
-    'mainz': 'DE',
-    'mainzgrid': 'DE',
-    'Mainz_MogonI': 'DE',
-    'CA-SCINET-T2': 'CA',
-    'Alberta': 'CA',
-    'parallel': 'CA',
-    'jasper': 'CA',
-    'Illume': 'CA',
-    'illume': 'CA',
-    'illume-new': 'CA',
-    'Cedar': 'CA',
-    'RWTH-Aachen': 'DE',
-    'aachen': 'DE',
-    'wuppertalprod': 'DE',
-    'TUM': 'DE',
-    'Uppsala': 'SE',
-    'Bartol': 'US',
-    'UNI-DORTMUND': 'DE',
-    'LIDO_Dortmund': 'DE',
-    'PHIDO_Dortmund': 'DE',
-    'LIDO3_Dortmund_TEST': 'DE',
-    'UKI-NORTHGRID-MAN-HEP': 'UK',
-    'UKI-LT2-QMUL': 'UK',
-    'Bridges': 'US',
-    'Comet': 'US',
-    'HOSTED_STANFORD': 'US',
-    'Xstream': 'US',
-    'xstream': 'US',
-    'NPX': 'US',
-    'GZK': 'US',
-    'CHTC': 'US',
-    'Marquette': 'US',
-    'UMD': 'US',
-    'MSU': 'US',
-    'msu': 'US',
-    'PSU': 'US',
-    'Japan': 'JP',
-    'Chiba': 'JP',
-    'nbi': 'DK',
-    'NBI': 'DK',
-    'NBI_T3': 'DK',
-    'SDSC-PRP': 'US',
-    'SU-ITS-CE3': 'US',
-    'SU-ITS-CE2': 'US',
-    'Crane': 'US',
-    'UCSDT2': 'US',
-    'BNL-ATLAS': 'US',
-    'CIT_CMS_T2': 'US',
-    'Indiana': 'US',
-    'Stampede2': 'US',
-    'Clemson-Palmetto': 'US'
-}
+def get_country_from_site(site):
+    if site == 'other':
+        return 'other'
+    else:
+        return site.split('-')[0]
 
-institutions = {
-    'DESY-ZN': 'DESY',
-    'DESY-HH': 'DESY',
-    'DESY': 'DESY',
-    'Brussels': 'VUB',
-    'T2B_BE_IIHE': 'VUB',
-    'BEgrid-ULB-VUB': 'VUB',
-    'Guillimin': 'UAlberta',
-    'CA-MCGILL-CLUMEQ-T2': 'UAlberta',
-    'mainz': 'Mainz',
-    'mainzgrid': 'Mainz',
-    'Mainz_MogonI': 'Mainz',
-    'CA-SCINET-T2': 'UAlberta',
-    'Alberta': 'UAlberta',
-    'parallel': 'UAlberta',
-    'jasper': 'UAlberta',
-    'Illume': 'UAlberta',
-    'illume': 'UAlberta',
-    'illume-new': 'UAlberta',
-    'Cedar': 'UAlberta',
-    'RWTH-Aachen': 'Aachen',
-    'aachen': 'Aachen',
-    'wuppertalprod': 'Wuppertal',
-    'TUM': 'TUM',
-    'Uppsala': 'Uppsala',
-    'Bartol': 'Bartol',
-    'UNI-DORTMUND': 'Dortmund',
-    'LIDO_Dortmund': 'Dortmund',
-    'PHIDO_Dortmund': 'Dortmund',
-    'LIDO3_Dortmund_TEST': 'Dortmund',
-    'UKI-NORTHGRID-MAN-HEP': 'QML',
-    'UKI-LT2-QMUL': 'QML',
-    'Bridges': 'XSEDE',
-    'Comet': 'XSEDE',
-    'HOSTED_STANFORD': 'OSG',
-    'Xstream': 'XSEDE',
-    'xstream': 'XSEDE',
-    'NPX': 'UW',
-    'GZK': 'UW',
-    'CHTC': 'UW',
-    'Marquette': 'Marquette',
-    'UMD': 'UMD',
-    'MSU': 'MSU',
-    'msu': 'MSU',
-    'PSU': 'PSU',
-    'Japan': 'Chiba',
-    'Chiba': 'Chiba',
-    'nbi': 'NBI',
-    'NBI': 'NBI',
-    'NBI_T3': 'NBI',
-    'SDSC-PRP': 'OSG',
-    'SU-ITS-CE3': 'OSG',
-    'SU-ITS-CE2': 'OSG',
-    'Crane': 'OSG',
-    'UCSDT2': 'OSG',
-    'BNL-ATLAS': 'OSG',
-    'CIT_CMS_T2': 'OSG',
-    'Indiana': 'OSG',
-    'Stampede2': 'XSEDE',
-    'Clemson-Palmetto': 'OSG'
-}
+def get_institution_from_site(site):
+    if site == 'other':
+        return 'other'
+    else:
+        parts = site.split('-')
+        if 'OSG' in parts:
+            return 'OSG'
+        elif 'XSEDE' in parts:
+            return 'XSEDE'
+        else:
+            return '-'.join(parts[1:])
 
 # pre-estimated values
 gpu_ns_photon = OrderedDict([
@@ -686,22 +594,13 @@ def add_classads(data):
         data[site_key] = 'Illume'
 
     # add site
-    if data[site_key] in site_names:
-        data['site'] = site_names[data[site_key]]
-    else:
-        data['site'] = 'other'
+    data['site'] = get_site_from_resource(data[site_key])
 
     # add countries
-    if data[site_key] in countries:
-        data['country'] = countries[data[site_key]]
-    else:
-        data['country'] = 'other'
+    data['country'] = get_country_from_site(data['site'])
 
     # add institution
-    if data[site_key] in institutions:
-        data['institution'] = institutions[data[site_key]]
-    else:
-        data['institution'] = 'other'
+    data['institution'] = get_institution_from_site(data['site'])
 
     # Add gpuhrs and cpuhrs
     data['gpuhrs'] = data.get('Requestgpus', 0.) * data['walltimehrs']
@@ -795,12 +694,13 @@ def read_status_from_collector(address, after=datetime.now()-timedelta(hours=1))
         "Arch",
         "OpSysAndVer",
         "GLIDEIN_Site",
-        "GLIDEIN_ResourceName",
+        "GLIDEIN_SiteResource",
     ]
     temp_keys = [
         "AddressV1",
         "GPU_NAMES",
     ]
+    site_key = "GLIDEIN_SiteResource"
     try:
         gen = coll.query(
             htcondor.AdTypes.Startd,
@@ -819,10 +719,13 @@ def read_status_from_collector(address, after=datetime.now()-timedelta(hours=1))
             if data["LastHeardFrom"] > data["DaemonStartTime"]:
                 data["@timestamp"].append(data["LastHeardFrom"])
             data["duration"] = int((data["LastHeardFrom"]-data["DaemonStartTime"]).total_seconds())
-            if not 'GLIDEIN_ResourceName' in data:
-                data['GLIDEIN_ResourceName'] = data['GLIDEIN_Site']
+            # Pick up resource names from OSG glideins (GLIDEIN_SiteResource) and pyglidein (usually GLIDEIN_ResourceName="ResourceName")
+            if data.get(site_key, 'ResourceName') == 'ResourceName':
+                data[site_key] = data['GLIDEIN_Site']
+            data['resource'] = data[site_key]
+
             # add site
-            if is_bad_site(data, 'GLIDEIN_ResourceName'):
+            if is_bad_site(data, site_key):
                 site = get_site_from_domain(data['Name'].split('@')[-1])
                 if site:
                     data['site'] = site
@@ -833,27 +736,19 @@ def read_status_from_collector(address, after=datetime.now()-timedelta(hours=1))
                         data['site'] = site
                     else:
                         data['site'] = 'other'
-            elif data['GLIDEIN_ResourceName'] in site_names:
-                data['site'] = site_names[data['GLIDEIN_ResourceName']]
             else:
-                data['site'] = 'other'
+                data['site'] = get_site_from_resource(data[site_key])
 
             # add countries
-            if data['GLIDEIN_ResourceName'] in countries:
-                data['country'] = countries[data['GLIDEIN_ResourceName']]
-            else:
-                data['country'] = 'other'
-    
+            data['country'] = get_country_from_site(data['site'])
+
             # add institution
-            if data['GLIDEIN_ResourceName'] in institutions:
-                data['institution'] = institutions[data['GLIDEIN_ResourceName']]
-            else:
-                data['institution'] = 'other'
+            data['institution'] = get_institution_from_site(data['site'])
 
             for k in data.keys():
                 if k.startswith('GLIDEIN'):
                     del data[k]
-            normalize_gpu(data, 'TotalGPUs', 'GLIDEIN_ResourceName', 'GPU_NAMES')
+            normalize_gpu(data, 'TotalGPUs', 'GLIDEIN_SiteResource', 'GPU_NAMES')
             for k in temp_keys:
                 if k in data:
                     del data[k]

--- a/condor_utils.py
+++ b/condor_utils.py
@@ -743,7 +743,7 @@ def read_from_file(filename):
             else:
                 entry += line+'\n'
 
-def read_from_collector(address, history=False):
+def read_from_collector(address, history=False, constraint='true', projection=[]):
     """Connect to condor collectors and schedds to pull job ads directly.
 
     A generator that yields condor job dicts.
@@ -763,9 +763,9 @@ def read_from_collector(address, history=False):
             if history:
                 start_dt = datetime.now()-timedelta(minutes=10)
                 start_stamp = time.mktime(start_dt.timetuple())
-                gen = schedd.history('EnteredCurrentStatus >= {0}'.format(start_stamp),[],10000)
+                gen = schedd.history('(EnteredCurrentStatus >= {0}) && ({1})'.format(start_stamp,constraint),projection,10000)
             else:
-                gen = schedd.query()
+                gen = schedd.query(constraint, projection)
             for i,entry in enumerate(gen):
                 yield classad_to_dict(entry)
             logging.info('got %d entries', i)


### PR DESCRIPTION
This adds a group of new fields to the condor_status index of the form `occupancy.{category}.{resource}`, where `category` is one of (finished,removed,evicted,total) and resource is one of (GPUs,Cpus,Memory,Disk). These can be interpreted as the fraction of the glidein's lifetime that the corresponding resources were claimed by jobs assigned to one of its slots. This should provide better insight into how well a pyglidein site's resources are being used.

For example, an `occupancy.total.*` of 0 means that no jobs were assigned to the glidein, ever, and an `occupancy.evicted.*` of 1 means that the glidein expired before it could finish any work.

The `claim` and `occupancy` metric updates are implemented as server-side Painless scripts.

There are some edge cases that are ugly but not fatal. Since the glidein's lifetime is estimated from LastHeardFrom-DaemonStartTime, it is only a lower limit on the actual lifetime. This means that `occupancy` can be larger than 1 if the machine classad is removed from the collector between polls. Similarly, if a job is evicted from machine A, rescheduled on machine B, and evicted again (from machine B) between polls, the resource claim on machine A will not be recorded. Short of instrumenting all glideins or the being able to subscribe to classad updates, there's not a good way to fix these.